### PR TITLE
Publish 1709.10

### DIFF
--- a/windows-stemcell-v1709x.html.md.erb
+++ b/windows-stemcell-v1709x.html.md.erb
@@ -9,6 +9,16 @@ To download a stemcell, see [Stemcells for PCF (Windows)](https://network.pivota
 
 <p class="note"><strong>Note:</strong> As of the PCF v2.1.0 release, Amazon Web Services (AWS) stemcell v1709.x for Windows Server 2016 is longer available on <a href="https://network.pivotal.io/products/stemcells-windows-server">Pivotal Network</a>.</p>
 
+## <a id="1709.10"></a>1709.10
+
+**Release Date**: June 27, 2018
+
+### Bug Fix
+* Updated the bosh-davcli and the bosh-s3cli to the latest. 
+* Repairs NTP. Specifically, run time sync command via Powershell to strip quotes from NTP server. [Tracker Story]((https://www.pivotaltracker.com/n/projects/1479998/stories/157879237))
+
+The source code and other assets are available on [GitHub](https://github.com/cloudfoundry-incubator/bosh-windows-stemcell-builder/releases/tag/1709.8).
+
 
 ## <a id="1709.8"></a>1709.8
 


### PR DESCRIPTION
We still won't be publishing 1709 for AWS yet. This is for the other IaaSes. 