### PR TITLE
Stemcell 3233.1 - Fix the URL link for KB article

### DIFF
--- a/stemcells.html.md.erb
+++ b/stemcells.html.md.erb
@@ -1532,7 +1532,7 @@ For more information about Meltdown, see the [Meltdown and Spectre Attacks](http
 </br>
 This update may include degradations to performance if your VM's CPU and memory usage are currently at near-capacity levels.
 Prior to upgrading to this stemcell, monitor your PCF VM's current CPU and memory usage and scale those components if necessary. If any of your VMs are currently operating at 60% or above, Pivotal recommends scaling that VM.
-For more information about the performance impact of Meltdown-related stemcell patches on PCF components and guidance on scaling, see this [KB article](https://discuss.pivotal.io/hc/en-us/articles/360000309953).
+For more information about the performance impact of Meltdown-related stemcell patches on PCF components and guidance on scaling, see this [KB article](https://community.pivotal.io/s/article/Performance-Impact-of-Cloud-Foundry-Apps-and-Services-Because-of-Spectre-and-Meltdown).
 </br>
 </br>
 For more information about monitoring and scaling PCF, see the [Monitoring PCF VMs from Ops Manager](http://docs.pivotal.io/pivotalcf/2-0/customizing/monitoring.html),


### PR DESCRIPTION
Fix the URL link for the KB article regarding Performance Impact of Cloud Foundry Apps and Services Because of Spectre and Meltdown.

The current URL works but it's obsolete URL and the http request is forwarded to the following new URL link.
https://community.pivotal.io/s/article/Performance-Impact-of-Cloud-Foundry-Apps-and-Services-Because-of-Spectre-and-Meltdown

The obsolete URL won't work in the near future. So please fix the link to new one.