### PR TITLE
Using the correct proper nouns for Windows Server

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -58,8 +58,8 @@ For information on which <%= vars.product_name %> tile releases now use Xenial, 
 
 This section lists Windows-based stemcells used in <%= vars.product_name %>. Each stemcell line has a corresponding release notes section. See the links below:
 
-* [Stemcell 2019.x (Windows Server version 2019) Release Notes](./windows-stemcell-v2019x.html)
-* [Stemcell 1803.x (Windows Server version 1803) Release Notes](./windows-stemcell-v1803x.html)
-* [Stemcell 1709.x (Windows Server version 1709) Release Notes](./windows-stemcell-v1709x.html)
-* [Stemcell 1200.x (Windows2012R2) Release Notes](./windows-stemcell-v1200x.html)
+* [Stemcell 2019.x (Windows Server 2019) Release Notes](./windows-stemcell-v2019x.html)
+* [Stemcell 1803.x (Windows Server, version 1803) Release Notes](./windows-stemcell-v1803x.html)
+* [Stemcell 1709.x (Windows Server, version 1709) Release Notes](./windows-stemcell-v1709x.html)
+* [Stemcell 1200.x (Windows Server 2012R2) Release Notes](./windows-stemcell-v1200x.html)
 


### PR DESCRIPTION
This page is confusing because it does not strictly use the Windows Server naming conventions. LTSC has a year after it, and SAC says "version" before the build number.