### PR TITLE
Remove jammy stemcell release notes

### DIFF
--- a/ci/get-stemcells.rb
+++ b/ci/get-stemcells.rb
@@ -5,10 +5,6 @@ require 'base64'
 
 
 STEMCELL_RELEASES = {
-  jammy: {
-    tanzunet_uri: 'https://network.pivotal.io/api/v2/products/stemcells-ubuntu-jammy/releases',
-    supported_lines: %w(0),
-  },
   xenial: {
     tanzunet_uri: 'https://network.pivotal.io/api/v2/products/stemcells-ubuntu-xenial/releases',
     supported_lines: %w(621 456),

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -62,12 +62,6 @@ in _IPsec_.
 
 For information about which tile releases use Xenial, see [Tiles Using Xenial Stemcells](xenial-tiles.html).
 
-###<a id="jammy"></a> Jammy Stemcells
-
-See the [Jammy Release Notes](./stemcells.html#jammy) for more information.
-
-Ubuntu 22.04 LTS (Jammy) will not be supported after its End of Standard Support (April 2027).
-
 ## <a id="windows"></a> Windows Stemcell Lines
 
 This section lists Windows-based stemcells used by <%= vars.platform_name %>. Each stemcell line


### PR DESCRIPTION
* Jammy stemcell has not been released, and including the release notes
for dev versions may cause confusion and lead customers to think that
jammy is ready to try out

Co-authored-by: Seth Boyles <sethboyles@gmail.com>
Co-authored-by: Brian Cunnie <bcunnie@vmware.com>