### PR TITLE
Refer to 621.x rather than 612.x

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -40,7 +40,7 @@ This section lists Linux-based stemcells used by <%= vars.platform_name %>.
 
 Each stemcell line has a corresponding release notes section. See the links below:
 
-* [Stemcell 612.x Release Notes](./stemcells.html#612-line)
+* [Stemcell 621.x Release Notes](./stemcells.html#621-line)
 * [Stemcell 456.x Release Notes](./stemcells.html#456-line)
 
 Ubuntu 16.04 LTS (Xenial) will be supported until 2024


### PR DESCRIPTION
I assume this was a typo when added originally.