### PR TITLE
Links to Microsoft allow for internationalization

### DIFF
--- a/windows-stemcell-v2019x.html.md.erb
+++ b/windows-stemcell-v2019x.html.md.erb
@@ -26,7 +26,7 @@ To download a stemcell, see [Stemcells (Windows)](https://network.pivotal.io/pro
 
 ### Security Patches
 
-Works with [Microsoft Security Updates Patch Tuesday July 11th, 2023](https://support.microsoft.com/en-gb/help/5028168)
+Works with [Microsoft Security Updates Patch Tuesday July 11th, 2023](https://support.microsoft.com/help/5028168)
 
 ## <a id="2019.62"></a>2019.62
 
@@ -34,7 +34,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 11th, 2023](https://su
 
 ### Security Patches
 
-Works with [Microsoft Security Updates Patch Tuesday June 13th, 2023](https://support.microsoft.com/en-gb/help/5027222)
+Works with [Microsoft Security Updates Patch Tuesday June 13th, 2023](https://support.microsoft.com/help/5027222)
 
 ## <a id="2019.61"></a>2019.61
 
@@ -42,7 +42,7 @@ Works with [Microsoft Security Updates Patch Tuesday June 13th, 2023](https://su
 
 ### Security Patches
 
-Works with [Microsoft Security Updates Patch Tuesday May 9th, 2023](https://support.microsoft.com/en-gb/help/5026362)
+Works with [Microsoft Security Updates Patch Tuesday May 9th, 2023](https://support.microsoft.com/help/5026362)
 
 ## <a id="2019.60"></a>2019.60
 
@@ -50,7 +50,7 @@ Works with [Microsoft Security Updates Patch Tuesday May 9th, 2023](https://supp
 
 ### Security Patches
 
-Works with [Microsoft Security Updates Patch Tuesday April 11th, 2023](https://support.microsoft.com/en-gb/help/5025229)
+Works with [Microsoft Security Updates Patch Tuesday April 11th, 2023](https://support.microsoft.com/help/5025229)
 
 ## <a id="2019.59"></a>2019.59
 
@@ -58,7 +58,7 @@ Works with [Microsoft Security Updates Patch Tuesday April 11th, 2023](https://s
 
 ### Security Patches
 
-Works with [Microsoft Security Updates Patch Tuesday March 14th, 2023](https://support.microsoft.com/en-gb/help/5023702)
+Works with [Microsoft Security Updates Patch Tuesday March 14th, 2023](https://support.microsoft.com/help/5023702)
 
 ## <a id="2019.58"></a>2019.58
 
@@ -66,7 +66,7 @@ Works with [Microsoft Security Updates Patch Tuesday March 14th, 2023](https://s
 
 ### Security Patches
 
-Works with [Microsoft Security Updates Patch Tuesday February 14th, 2023](https://support.microsoft.com/en-us/help/5022840)
+Works with [Microsoft Security Updates Patch Tuesday February 14th, 2023](https://support.microsoft.com/help/5022840)
 
 ## <a id="2019.57"></a>2019.57
 
@@ -74,7 +74,7 @@ Works with [Microsoft Security Updates Patch Tuesday February 14th, 2023](https:
 
 ### Security Patches
 
-Works with [Microsoft Security Updates Patch Tuesday January 10th, 2023](https://support.microsoft.com/en-us/help/5022286)
+Works with [Microsoft Security Updates Patch Tuesday January 10th, 2023](https://support.microsoft.com/help/5022286)
 
 ## <a id="2019.56"></a>2019.56
 
@@ -82,7 +82,7 @@ Works with [Microsoft Security Updates Patch Tuesday January 10th, 2023](https:/
 
 ### Security Patches
 
-Works with [Microsoft Security Updates Patch Tuesday December 13th, 2022](https://support.microsoft.com/en-gb/help/5021237)
+Works with [Microsoft Security Updates Patch Tuesday December 13th, 2022](https://support.microsoft.com/help/5021237)
 
 ## <a id="2019.55"></a>2019.55
 
@@ -90,7 +90,7 @@ Works with [Microsoft Security Updates Patch Tuesday December 13th, 2022](https:
 
 ### Security Patches
 
-Works with [Microsoft Security Updates Patch Tuesday November 8th, 2022](https://support.microsoft.com/en-us/help/5019966)
+Works with [Microsoft Security Updates Patch Tuesday November 8th, 2022](https://support.microsoft.com/help/5019966)
 
 ## <a id="2019.54"></a>2019.54
 
@@ -98,7 +98,7 @@ Works with [Microsoft Security Updates Patch Tuesday November 8th, 2022](https:/
 
 ### Security Patches
 
-Works with [Microsoft Security Updates Patch Tuesday October 19, 2022](https://support.microsoft.com/en-us/topic/october-11-2022-kb5018419-os-build-17763-3532-ca62cca7-b599-44c4-a2a6-347996662623)
+Works with [Microsoft Security Updates Patch Tuesday October 19, 2022](https://support.microsoft.com/topic/october-11-2022-kb5018419-os-build-17763-3532-ca62cca7-b599-44c4-a2a6-347996662623)
 
 
 ## <a id="2019.53"></a>2019.53
@@ -107,7 +107,7 @@ Works with [Microsoft Security Updates Patch Tuesday October 19, 2022](https://s
 
 ### Security Patches
 
-Works with [Microsoft Security Updates Patch Tuesday September 13, 2022](https://support.microsoft.com/en-us/topic/september-13-2022-kb5017315-os-build-17763-3406-926525b2-750e-42e2-9845-49924d97281c)
+Works with [Microsoft Security Updates Patch Tuesday September 13, 2022](https://support.microsoft.com/topic/september-13-2022-kb5017315-os-build-17763-3406-926525b2-750e-42e2-9845-49924d97281c)
 
 ## <a id="2019.52"></a>2019.52
 
@@ -115,7 +115,7 @@ Works with [Microsoft Security Updates Patch Tuesday September 13, 2022](https:/
 
 ### Security Patches
 
-Works with [Microsoft Security Updates Patch Tuesday August 9, 2022](https://support.microsoft.com/en-us/topic/august-9-2022-kb5016623-os-build-17763-3287-c7a0bb3a-4083-4cd0-b9ad-119d9267628b)
+Works with [Microsoft Security Updates Patch Tuesday August 9, 2022](https://support.microsoft.com/topic/august-9-2022-kb5016623-os-build-17763-3287-c7a0bb3a-4083-4cd0-b9ad-119d9267628b)
 
 ## <a id="2019.51"></a>2019.51
 
@@ -123,7 +123,7 @@ Works with [Microsoft Security Updates Patch Tuesday August 9, 2022](https://sup
 
 ### Security Patches
 
-Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://support.microsoft.com/en-us/topic/july-12-2022-kb5015811-os-build-17763-3165-f3bdb13c-d767-47dc-a077-0ea0e9421a96)
+Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://support.microsoft.com/topic/july-12-2022-kb5015811-os-build-17763-3165-f3bdb13c-d767-47dc-a077-0ea0e9421a96)
 
 ## <a id="2019.50"></a>2019.50
 
@@ -139,7 +139,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday June 14, 2022](https://support.microsoft.com/en-us/help/5014692)
+- Works with [Microsoft Security Updates Patch Tuesday June 14, 2022](https://support.microsoft.com/help/5014692)
 
 ## <a id="2019.48"></a>2019.48
 
@@ -151,7 +151,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday May 10, 2022](https://support.microsoft.com/en-us/help/5013941)
+- Works with [Microsoft Security Updates Patch Tuesday May 10, 2022](https://support.microsoft.com/help/5013941)
 
 ## <a id="2019.47"></a>2019.47
 
@@ -159,7 +159,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday April 12, 2022](https://support.microsoft.com/en-us/help/5012647)
+- Works with [Microsoft Security Updates Patch Tuesday April 12, 2022](https://support.microsoft.com/help/5012647)
 
 
 ## <a id="2019.46"></a>2019.46
@@ -168,7 +168,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday March 8, 2022](https://support.microsoft.com/en-us/help/5011503)
+- Works with [Microsoft Security Updates Patch Tuesday March 8, 2022](https://support.microsoft.com/help/5011503)
 
 ## <a id="2019.45"></a>2019.45
 
@@ -176,7 +176,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday February 8, 2022](https://support.microsoft.com/en-us/help/5010351)
+- Works with [Microsoft Security Updates Patch Tuesday February 8, 2022](https://support.microsoft.com/help/5010351)
 
 ## <a id="2019.44"></a>2019.44
 
@@ -184,7 +184,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday January 11, 2022](https://support.microsoft.com/en-us/help/5009557)
+- Works with [Microsoft Security Updates Patch Tuesday January 11, 2022](https://support.microsoft.com/help/5009557)
 
 ## <a id="2019.43"></a>2019.43
 
@@ -192,7 +192,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday December 14, 2021](https://support.microsoft.com/en-us/help/5008218)
+- Works with [Microsoft Security Updates Patch Tuesday December 14, 2021](https://support.microsoft.com/help/5008218)
 
 ## <a id="2019.42"></a>2019.42
 
@@ -200,7 +200,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday November 9, 2021](https://support.microsoft.com/en-us/help/5007206)
+- Works with [Microsoft Security Updates Patch Tuesday November 9, 2021](https://support.microsoft.com/help/5007206)
 
 ## <a id="2019.41"></a>2019.41
 
@@ -208,7 +208,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday October 12, 2021](https://support.microsoft.com/en-us/help/5006672)
+- Works with [Microsoft Security Updates Patch Tuesday October 12, 2021](https://support.microsoft.com/help/5006672)
 
 ## <a id="2019.40"></a>2019.40
 
@@ -216,7 +216,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday September 14, 2021](https://support.microsoft.com/en-us/help/5005568)
+- Works with [Microsoft Security Updates Patch Tuesday September 14, 2021](https://support.microsoft.com/help/5005568)
 
 ## <a id="2019.39"></a>2019.39
 
@@ -224,7 +224,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday August 10, 2021](https://support.microsoft.com/en-us/help/5005030)
+- Works with [Microsoft Security Updates Patch Tuesday August 10, 2021](https://support.microsoft.com/help/5005030)
 
 ## <a id="2019.38"></a>2019.38
 
@@ -232,7 +232,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday July 12, 2021](https://support.microsoft.com/en-us/help/5004244)
+- Works with [Microsoft Security Updates Patch Tuesday July 12, 2021](https://support.microsoft.com/help/5004244)
 
 ## <a id="2019.37"></a>2019.37
 
@@ -240,7 +240,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday June 8, 2021](https://support.microsoft.com/en-us/help/5003646)
+- Works with [Microsoft Security Updates Patch Tuesday June 8, 2021](https://support.microsoft.com/help/5003646)
 
 ## <a id="2019.36"></a>2019.36
 
@@ -248,7 +248,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday May 11, 2021](https://support.microsoft.com/en-us/help/5003171)
+- Works with [Microsoft Security Updates Patch Tuesday May 11, 2021](https://support.microsoft.com/help/5003171)
 
 ## <a id="2019.35"></a>2019.35
 
@@ -256,7 +256,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday April 13, 2021](https://support.microsoft.com/en-us/help/5001342)
+- Works with [Microsoft Security Updates Patch Tuesday April 13, 2021](https://support.microsoft.com/help/5001342)
 
 ## <a id="2019.34"></a>2019.34
 
@@ -274,7 +274,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday March 9, 2021](https://support.microsoft.com/en-us/help/5000822)
+- Works with [Microsoft Security Updates Patch Tuesday March 9, 2021](https://support.microsoft.com/help/5000822)
 
 ## <a id="2019.31"></a>2019.31
 
@@ -282,7 +282,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday February 9, 2021](https://support.microsoft.com/en-us/help/4601345)
+- Works with [Microsoft Security Updates Patch Tuesday February 9, 2021](https://support.microsoft.com/help/4601345)
 
 ## <a id="2019.30"></a>2019.30
 
@@ -290,7 +290,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday January 12, 2021](https://support.microsoft.com/en-us/help/4598230)
+- Works with [Microsoft Security Updates Patch Tuesday January 12, 2021](https://support.microsoft.com/help/4598230)
 
 ## <a id="2019.29"></a>2019.29
 
@@ -298,7 +298,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday December 8, 2020](https://support.microsoft.com/en-us/help/4592440)
+- Works with [Microsoft Security Updates Patch Tuesday December 8, 2020](https://support.microsoft.com/help/4592440)
 
 ## <a id="2019.28"></a>2019.28
 
@@ -306,7 +306,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 
 ### Security Patches
 
-- Works with [Microsoft Security Updates Patch Tuesday November 10, 2020](https://support.microsoft.com/en-us/help/4586793)
+- Works with [Microsoft Security Updates Patch Tuesday November 10, 2020](https://support.microsoft.com/help/4586793)
 
 ### Changes
 
@@ -320,7 +320,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 ### Security Fix
 - Includes the Tuesday October 13th, 2020 Microsoft security updates patch.
  For more information, see
- [October 13, 2020—KB4577668 (OS Build 17763.1518)](https://support.microsoft.com/en-us/help/4577668)
+ [October 13, 2020—KB4577668 (OS Build 17763.1518)](https://support.microsoft.com/help/4577668)
  in the Microsoft Windows support documentation.
 
 ## <a id="2019.26"></a>2019.26
@@ -330,7 +330,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 ### Security Fix
 - Includes the Tuesday September 8th, 2020 Microsoft security updates patch.
  For more information, see
- [September 8, 2020—KB4570333 (OS Build 17763.1457)](https://support.microsoft.com/en-us/help/4570333)
+ [September 8, 2020—KB4570333 (OS Build 17763.1457)](https://support.microsoft.com/help/4570333)
  in the Microsoft Windows support documentation.
 
 <p class="note"><strong>Note</strong>: This release does not include an Azure stemcell due
@@ -344,7 +344,7 @@ Works with [Microsoft Security Updates Patch Tuesday July 12, 2022](https://supp
 ### Security Fix
 - Includes the Tuesday August 25th, 2020 Microsoft security updates patch.
  For more information, see
- [August 11, 2020—KB4565349 (OS Build 17763.1397)](https://support.microsoft.com/en-us/help/4565349/windows-10-update-kb4565349)
+ [August 11, 2020—KB4565349 (OS Build 17763.1397)](https://support.microsoft.com/help/4565349/windows-10-update-kb4565349)
  in the Microsoft Windows support documentation.
 
 ### Bug Fix
@@ -362,7 +362,7 @@ After this release, you must use the stembuild-based approach to build stemcells
 ### Security Fix
  - Includes the Tuesday July 14th, 2020 Microsoft security update patch.
  For more information, see
- [July 14th, 2020—KB4558998 (OS Build 17763.1339)](https://support.microsoft.com/en-us/help/4558998/windows-10-update-kb4558998)
+ [July 14th, 2020—KB4558998 (OS Build 17763.1339)](https://support.microsoft.com/help/4558998/windows-10-update-kb4558998)
  in the Microsoft Windows support documentation.
 
 
@@ -377,7 +377,7 @@ For more information about stembuild, see [Creating a Windows Stemcell for vSphe
 ### Security Fix
  - Includes the Tuesday June 9th, 2020 Microsoft security update patch.
  For more information, see
- [June 9, 2020—KB4561608 (OS Build 17763.1282)](https://support.microsoft.com/en-us/help/4561608)
+ [June 9, 2020—KB4561608 (OS Build 17763.1282)](https://support.microsoft.com/help/4561608)
  in the Microsoft Windows support documentation.
 
 ### Features
@@ -399,7 +399,7 @@ See
 **Release Date**: May 21st, 2020
 
 ### Security Fix
-- Includes [Microsoft Security Updates Patch Tuesday May 12th, 2020](https://support.microsoft.com/en-us/help/4551853)
+- Includes [Microsoft Security Updates Patch Tuesday May 12th, 2020](https://support.microsoft.com/help/4551853)
 
 ### Features
 - `stembuild construct` streams logs after the target VM reboots. Stembuild reconnects to the target VM using WinRM to stream logs after the VM reboot, showing you what is occurring on your target VM.
@@ -417,7 +417,7 @@ See
 
 ### Security Fixes
 
-- Includes [Microsoft Security Updates Patch Tuesday April 14th, 2020](https://support.microsoft.com/en-us/help/4549949)
+- Includes [Microsoft Security Updates Patch Tuesday April 14th, 2020](https://support.microsoft.com/help/4549949)
 
 
 ## <a id="2019.19"></a>2019.19
@@ -432,7 +432,7 @@ This stemcell and later v2019.x versions work with:
 
 ### Security Fixes
 
-- Includes [Microsoft Security Updates Patch Tuesday March 10th, 2020](https://support.microsoft.com/en-us/help/4538461)
+- Includes [Microsoft Security Updates Patch Tuesday March 10th, 2020](https://support.microsoft.com/help/4538461)
 - For issues encountered with upgrading to the correct <%= vars.windows_runtime_abbr %> versions, see the following articles in the Knowledge Base:
   - [windows2019fs cert-injector failed when upgrading <%= vars.windows_runtime_abbr %> tile](https://community.pivotal.io/s/article/windows2019fs-cert-injector-failed-when-upgrading-PASW-tile)
   - [Windows container crashes on Windows Stemcells created on vSphere with VMware tools 11.0.1-11.0.5](https://community.pivotal.io/s/article/windows-app-container-crashing-after-Windows-stemcell-upgrade)
@@ -454,7 +454,7 @@ This stemcell and later v2019.x versions work with:
 
 ### Security Fixes
 
-- Includes [Microsoft Security Updates Patch Tuesday February 11, 2020](https://support.microsoft.com/en-us/help/4532691).
+- Includes [Microsoft Security Updates Patch Tuesday February 11, 2020](https://support.microsoft.com/help/4532691).
 - For issues encountered with upgrading to the correct <%= vars.windows_runtime_abbr %> versions, see the following articles in the Knowledge Base:
   - [windows2019fs cert-injector failed when upgrading <%= vars.windows_runtime_abbr %> tile](https://community.pivotal.io/s/article/windows2019fs-cert-injector-failed-when-upgrading-PASW-tile)
   - [Windows container crashes on Windows Stemcells created on vSphere with VMware tools 11.0.1-11.0.5](https://community.pivotal.io/s/article/windows-app-container-crashing-after-Windows-stemcell-upgrade)
@@ -490,7 +490,7 @@ in the Knowledge Base.
 
 ### Security Fixes
 
-- Includes [Microsoft Security Updates Patch Tuesday January 2020](https://portal.msrc.microsoft.com/en-us/security-guidance/releasenotedetail/2020-Jan). This release includes fixes for [CVE-2020-0601](https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-0601).
+- Includes [Microsoft Security Updates Patch Tuesday January 2020](https://portal.msrc.microsoft.com/security-guidance/releasenotedetail/2020-Jan). This release includes fixes for [CVE-2020-0601](https://portal.msrc.microsoft.com/security-guidance/advisory/CVE-2020-0601).
 
 ### Known Issues
 
@@ -505,7 +505,7 @@ in the Knowledge Base.
 
 ### Security Fixes
 
-- Includes [Microsoft Security Updates Patch Tuesday December 2019](https://support.microsoft.com/en-us/help/4530715)
+- Includes [Microsoft Security Updates Patch Tuesday December 2019](https://support.microsoft.com/help/4530715)
 
 ### Features
 
@@ -519,7 +519,7 @@ in the Knowledge Base.
 
 ### Security Fixes
 
-- Includes [Microsoft Security Updates Patch Tuesday November 2019](https://support.microsoft.com/en-us/help/4523205)
+- Includes [Microsoft Security Updates Patch Tuesday November 2019](https://support.microsoft.com/help/4523205)
 
 ### Features
 
@@ -533,7 +533,7 @@ in the Knowledge Base.
 
 ### Security Fixes
 
-- Includes [Microsoft Security Updates Patch Tuesday October 2019](https://support.microsoft.com/en-us/help/4519338)
+- Includes [Microsoft Security Updates Patch Tuesday October 2019](https://support.microsoft.com/help/4519338)
 
 ### Features
 
@@ -553,12 +553,12 @@ in the Knowledge Base.
 
 ### Security Fixes
 
-- Includes [Microsoft Security Updates Patch Tuesday September 2019](https://support.microsoft.com/en-us/help/4512578)
+- Includes [Microsoft Security Updates Patch Tuesday September 2019](https://support.microsoft.com/help/4512578)
 
 ### Features
 
 - Enabled the Hyper-V Windows feature for enabling Windows 2019 stemcells built using stembuild
-- Improved security hardening of Windows stemcells by aligning Internet Explorer-based policies with the [Microsoft Baseline Security Standard](https://docs.microsoft.com/en-us/windows/security/threat-protection/security-compliance-toolkit-10)
+- Improved security hardening of Windows stemcells by aligning Internet Explorer-based policies with the [Microsoft Baseline Security Standard](https://docs.microsoft.com/windows/security/threat-protection/security-compliance-toolkit-10)
 
 ### Bug Fixes
 
@@ -576,8 +576,8 @@ in the Knowledge Base.
 
 ### Features
 
-- Includes [Microsoft Security Updates Patch Tuesday August 2019](https://support.microsoft.com/en-us/help/4511553)
-- Aligned a set of audit policies on the stemcells based on [Microsoft Baseline Security Standard](https://www.microsoft.com/en-us/download/details.aspx?id=55319)
+- Includes [Microsoft Security Updates Patch Tuesday August 2019](https://support.microsoft.com/help/4511553)
+- Aligned a set of audit policies on the stemcells based on [Microsoft Baseline Security Standard](https://www.microsoft.com/download/details.aspx?id=55319)
 - Introduced a new feature in `stembuild construct` command to validate/invalidate the OS based on stembuild version.
 
 
@@ -587,7 +587,7 @@ in the Knowledge Base.
 
 ### Features
 
-- Includes [Microsoft Security Updates Patch Tuesday July 2019](https://support.microsoft.com/en-us/help/4507469)
+- Includes [Microsoft Security Updates Patch Tuesday July 2019](https://support.microsoft.com/help/4507469)
 - Windows Defender is installed but disabled on all stemcells.
 
 
@@ -607,7 +607,7 @@ in the Knowledge Base.
 
 ### Security Fixes
 
-- Includes Microsoft Security Updates [June 11, 2019—KB4503327](https://support.microsoft.com/en-us/help/4503327/windows-10-update-kb4503327)
+- Includes Microsoft Security Updates [June 11, 2019—KB4503327](https://support.microsoft.com/help/4503327/windows-10-update-kb4503327)
 - Introduces 2.3.1.2 (L1) and 1.1.1 (L1) CIS L1 policy hardenings based on the CIS Security Benchmark.
 
 
@@ -617,7 +617,7 @@ in the Knowledge Base.
 
 ### Security Fixes
 
-- Based on [Microsoft's guidance](https://support.microsoft.com/en-us/help/4072698/windows-server-speculative-execution-side-channel-vulnerabilities-prot#section-10), additional fixes to protect against speculative execution side-channel vulnerabilities
+- Based on [Microsoft's guidance](https://support.microsoft.com/help/4072698/windows-server-speculative-execution-side-channel-vulnerabilities-prot#section-10), additional fixes to protect against speculative execution side-channel vulnerabilities
 
 
 ## <a id="2019.4"></a>2019.4
@@ -628,7 +628,7 @@ in the Knowledge Base.
 
 - Platform Engineers can deploy Windows Stemcells on a BOSH Director with Google Cloud Storage as their external Blobstore.
 - Improved Troubleshooting of Windows VMs, with ssh enabled by default for all Windows VMs. You can still disable SSH in the <%= vars.windows_runtime_abbr %> tile.
-- Includes Microsoft Security Updates to protect against Microarchitectural Data Sampling side-channel vulnerabilities. For more information, see [May 14, 2019—KB4494441 (OS Build 17763.503)](https://support.microsoft.com/en-us/help/4494441/windows-10-update-kb4494441) in the Windows support documentation.
+- Includes Microsoft Security Updates to protect against Microarchitectural Data Sampling side-channel vulnerabilities. For more information, see [May 14, 2019—KB4494441 (OS Build 17763.503)](https://support.microsoft.com/help/4494441/windows-10-update-kb4494441) in the Windows support documentation.
 
 ## <a id="2019.3"></a>2019.3
 
@@ -637,4 +637,4 @@ in the Knowledge Base.
 ### Features
 
 - This is the first 2019 stemcell.
-- Includes [Microsoft Security Updates Patch Tuesday April 2019](https://support.microsoft.com/en-us/help/4493509)
+- Includes [Microsoft Security Updates Patch Tuesday April 2019](https://support.microsoft.com/help/4493509)


### PR DESCRIPTION
Previously we hard-coded the language in the link (e.g. `en-us` and, surprisingly, `en-gb`). With this commit we enable Microsoft to determine the appropriate language from the user's browser, and display the information accordingly.